### PR TITLE
Colors

### DIFF
--- a/inc/RTreeMap.hxx
+++ b/inc/RTreeMap.hxx
@@ -1,7 +1,7 @@
 #ifndef TREEMAP_HXX
 #define TREEMAP_HXX
 
-#include <ROOT/RPadBase.hxx>
+#include <ROOT/RDrawable.hxx>
 #include <ROOT/RCanvas.hxx>
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleInspector.hxx>
@@ -15,27 +15,27 @@ public:
    const std::uint64_t GetSize() const { return fSize; }
    const std::uint64_t GetNChildren() const { return fNChildren; }
    const std::uint64_t GetChildrenIdx() const { return fChildrenIdx; }
+   const RColor GetColor() const { return fColor; }
 
-   RTreeMappable(const std::string name, const std::uint64_t size, const std::uint64_t childrenIdx,
+   RTreeMappable(const std::string name, const std::uint64_t size, const RColor color, const std::uint64_t childrenIdx,
                  const std::uint64_t nChildren)
-      : fName(name), fSize(size), fChildrenIdx(childrenIdx), fNChildren(nChildren)
+      : fName(name), fSize(size), fColor(color), fChildrenIdx(childrenIdx), fNChildren(nChildren)
    {
    }
 
 private:
    const std::uint64_t fChildrenIdx, fNChildren, fSize;
    const std::string fName;
+   const RColor fColor;
 };
 
-class RTreeMap : public RPadBase {
+class RTreeMap : public RDrawable {
 public:
    RTreeMap(std::shared_ptr<RCanvas> canvasArg, const std::vector<RTreeMappable> nodes)
-      : RPadBase("treemap"), fCanvas(canvasArg), fNodes(nodes)
+      : RDrawable("treemap"), fCanvas(canvasArg), fNodes(nodes)
    {
       DrawTreeMap(fNodes[0], {0, 0}, {1, 1}, 0);
    }
-   RCanvas *GetCanvas() override { return fCanvas.get(); }
-   const RCanvas *GetCanvas() const override { return fCanvas.get(); }
 
 private:
    const std::vector<RTreeMappable> fNodes;

--- a/inc/RTreeMap.hxx
+++ b/inc/RTreeMap.hxx
@@ -12,10 +12,10 @@ using namespace ROOT::Experimental;
 class RTreeMappable {
 public:
    const std::string &GetName() const { return fName; }
-   const std::uint64_t GetSize() const { return fSize; }
-   const std::uint64_t GetNChildren() const { return fNChildren; }
-   const std::uint64_t GetChildrenIdx() const { return fChildrenIdx; }
-   const RColor GetColor() const { return fColor; }
+   std::uint64_t GetSize() const { return fSize; }
+   std::uint64_t GetNChildren() const { return fNChildren; }
+   std::uint64_t GetChildrenIdx() const { return fChildrenIdx; }
+   RColor GetColor() const { return fColor; }
 
    RTreeMappable(const std::string name, const std::uint64_t size, const RColor color, const std::uint64_t childrenIdx,
                  const std::uint64_t nChildren)
@@ -24,9 +24,9 @@ public:
    }
 
 private:
-   const std::uint64_t fChildrenIdx, fNChildren, fSize;
-   const std::string fName;
-   const RColor fColor;
+   std::uint64_t fChildrenIdx, fNChildren, fSize;
+   std::string fName;
+   RColor fColor;
 };
 
 class RTreeMap : public RDrawable {

--- a/inc/RTreeMap.hxx
+++ b/inc/RTreeMap.hxx
@@ -31,15 +31,15 @@ private:
 
 class RTreeMap : public RDrawable {
 public:
-   RTreeMap(std::shared_ptr<RCanvas> canvasArg, const std::vector<RTreeMappable> nodes)
+   RTreeMap(std::shared_ptr<RCanvas> canvasArg, const std::vector<RTreeMappable> &nodes)
       : RDrawable("treemap"), fCanvas(canvasArg), fNodes(nodes)
    {
       DrawTreeMap(fNodes[0], {0, 0}, {1, 1}, 0);
    }
 
 private:
-   const std::vector<RTreeMappable> fNodes;
-   const std::shared_ptr<RCanvas> fCanvas;
+   std::vector<RTreeMappable> fNodes;
+   std::shared_ptr<RCanvas> fCanvas;
    void DrawTreeMap(const RTreeMappable &elem, const std::pair<float, float> &begin, const std::pair<float, float> &end,
                     int depth) const;
 };

--- a/src/RNTupleBrowser.cxx
+++ b/src/RNTupleBrowser.cxx
@@ -7,7 +7,7 @@
 #include <queue>
 
 /* hash string into RGB color with FNV-1a: used for speed and diffusion*/
-uint64_t ComputeFnv(const std::string &str)
+static uint64_t ComputeFnv(const std::string &str)
 {
    uint64_t h = 14695981039346656037ULL;
    for (char c : str)

--- a/src/RNTupleBrowser.cxx
+++ b/src/RNTupleBrowser.cxx
@@ -33,7 +33,10 @@ std::vector<RTreeMappable> RNTupleBrowser::CreateRTreeMappable() const
                             ? fInspector->GetFieldTreeInspector(fldDesc->GetId()).GetCompressedSize()
                             : rootSize;
 
-         nodes.push_back(RTreeMappable(fldDesc->GetFieldName(), size, childrenIdx, nChildren));
+         const auto hash = std::hash<std::string>()(fldDesc->GetTypeName());
+         const auto color = RColor((hash & 0xFF0000) >> 16, (hash & 0x00FF00) >> 8,
+                                   hash & 0x0000FF); // hash field type string and turn it into RGB
+         nodes.push_back(RTreeMappable(fldDesc->GetFieldName(), size, color, childrenIdx, nChildren));
 
          for (const auto childId : children) {
             const auto *childFldDesc = &descriptor.GetFieldDescriptor(childId);

--- a/src/RNTupleBrowser.cxx
+++ b/src/RNTupleBrowser.cxx
@@ -33,9 +33,11 @@ std::vector<RTreeMappable> RNTupleBrowser::CreateRTreeMappable() const
                             ? fInspector->GetFieldTreeInspector(fldDesc->GetId()).GetCompressedSize()
                             : rootSize;
 
-         const auto hash = std::hash<std::string>()(fldDesc->GetTypeName());
-         const auto color = RColor((hash & 0xFF0000) >> 16, (hash & 0x00FF00) >> 8,
-                                   hash & 0x0000FF); // hash field type string and turn it into RGB
+         /* hash string into RGB color with FNV-1a: used for speed and diffusion*/
+         uint64_t h = 14695981039346656037ULL;
+         for (char c : fldDesc->GetTypeName())
+            h = (h ^ static_cast<uint8_t>(c)) * 1099511628211ULL;
+         const auto color = RColor((h >> 16) & 0xFF, (h >> 8) & 0xFF, h & 0xFF);
          nodes.push_back(RTreeMappable(fldDesc->GetFieldName(), size, color, childrenIdx, nChildren));
 
          for (const auto childId : children) {

--- a/src/RNTupleBrowser.cxx
+++ b/src/RNTupleBrowser.cxx
@@ -6,6 +6,15 @@
 #include <iostream>
 #include <queue>
 
+/* hash string into RGB color with FNV-1a: used for speed and diffusion*/
+uint64_t ComputeFnv(const std::string &str)
+{
+   uint64_t h = 14695981039346656037ULL;
+   for (char c : str)
+      h = (h ^ static_cast<uint8_t>(c)) * 1099511628211ULL;
+   return h;
+}
+
 std::vector<RTreeMappable> RNTupleBrowser::CreateRTreeMappable() const
 {
    std::vector<RTreeMappable> nodes;
@@ -33,13 +42,9 @@ std::vector<RTreeMappable> RNTupleBrowser::CreateRTreeMappable() const
                             ? fInspector->GetFieldTreeInspector(fldDesc->GetId()).GetCompressedSize()
                             : rootSize;
 
-         /* hash string into RGB color with FNV-1a: used for speed and diffusion*/
-         uint64_t h = 14695981039346656037ULL;
-         for (char c : fldDesc->GetTypeName())
-            h = (h ^ static_cast<uint8_t>(c)) * 1099511628211ULL;
-         const auto color = RColor((h >> 16) & 0xFF, (h >> 8) & 0xFF, h & 0xFF);
+         const uint64_t &hash = ComputeFnv(fldDesc->GetTypeName());
+         const auto color = RColor((hash >> 16) & 0xFF, (hash >> 8) & 0xFF, hash & 0xFF);
          nodes.push_back(RTreeMappable(fldDesc->GetFieldName(), size, color, childrenIdx, nChildren));
-
          for (const auto childId : children) {
             const auto *childFldDesc = &descriptor.GetFieldDescriptor(childId);
             queue.push(childFldDesc);

--- a/src/RTreeMap.cxx
+++ b/src/RTreeMap.cxx
@@ -12,7 +12,9 @@ void RTreeMap::DrawTreeMap(const RTreeMappable &elem, const std::pair<float, flo
    const std::array<float, 2> drawBegin = {toPad(begin.first), toPad(begin.second)};
    const std::array<float, 2> drawEnd = {toPad(end.first), toPad(end.second)};
 
-   fCanvas->Draw<RBox>(RPadPos(drawBegin[0], drawBegin[1]), RPadPos(drawEnd[0], drawEnd[1]));
+   auto box = fCanvas->Add<RBox>(RPadPos(drawBegin[0], drawBegin[1]), RPadPos(drawEnd[0], drawEnd[1]));
+   box->fill.color = elem.GetColor();
+   box->fill.style = RAttrFill::kSolid;
    const std::uint64_t size = elem.GetSize();
    auto text = fCanvas->Add<RText>(RPadPos((drawBegin[0] + drawEnd[0]) / 2.0f, (drawBegin[1] + drawEnd[1]) / 2.0f),
                                    elem.GetName() + " (" + std::to_string(size) + ")");

--- a/src/RTreeMap.cxx
+++ b/src/RTreeMap.cxx
@@ -20,7 +20,6 @@ void RTreeMap::DrawTreeMap(const RTreeMappable &elem, const std::pair<float, flo
                                    elem.GetName() + " (" + std::to_string(size) + ")");
    text->text.align = RAttrText::kCenter;
    text->text.size = textSizeFactor / (depth + 1);
-   text->text.angle = (sliceVertical) ? 0 : 90;
 
    float currentPos = (sliceVertical) ? begin.first : begin.second;
    for (std::uint64_t i = 0; i < elem.GetNChildren(); ++i) {


### PR DESCRIPTION
This feature colors the treemap boxes by applying a fast and diffuse non cryptographic hash function FNV-1a on the type name string of the corresponding field.

Additionally, RTreeMap now inherits from RDrawable instead of RPadBase.